### PR TITLE
fix: update favicon and logo asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Site oficial do escritório Marcelo Baía Advocacia." />
-  <link rel="icon" href="/imagens/favicon.ico" />
-  <link rel="apple-touch-icon" href="/imagens/logo-512x512.png" />
+  <link rel="icon" href="/assets/images/favicon.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="/assets/images/logo-512x512.png" />
   <link rel="manifest" href="/site.webmanifest" />
-  <meta property="og:image" content="/imagens/logo-512x512.png" />
-  <meta name="twitter:image" content="/imagens/logo-512x512.png" />
+  <meta property="og:image" content="/assets/images/logo-512x512.png" />
+  <meta name="twitter:image" content="/assets/images/logo-512x512.png" />
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/public/index.html
+++ b/public/index.html
@@ -7,11 +7,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Site oficial do escritório Marcelo Baía Advocacia." />
-  <link rel="icon" href="/imagens/favicon.ico" />
-  <link rel="apple-touch-icon" href="/imagens/logo-512x512.png" />
+  <link rel="icon" href="/assets/images/favicon.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="/assets/images/logo-512x512.png" />
   <link rel="manifest" href="/site.webmanifest" />
-  <meta property="og:image" content="/imagens/logo-512x512.png" />
-  <meta name="twitter:image" content="/imagens/logo-512x512.png" />
+  <meta property="og:image" content="/assets/images/logo-512x512.png" />
+  <meta name="twitter:image" content="/assets/images/logo-512x512.png" />
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- replace legacy `/imagens` asset paths with `/assets/images`
- add `sizes="any"` to `<link rel="icon">`
- keep webmanifest link intact

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a63f2ec34c832ca5e554119335014c