### PR TITLE
Set homepage as default landing page

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -17,7 +17,7 @@ const Routes = () => {
       <ScrollToTop />
       <RouterRoutes>
         {/* Define your route here */}
-        <Route path="/" element={<AboutMarceloBaia />} />
+        <Route path="/" element={<Homepage />} />
         <Route path="/individual-practice-area-pages" element={<IndividualPracticeAreaPages />} />
         <Route path="/about-marcelo-ba-a" element={<AboutMarceloBaia />} />
         <Route path="/faq-hub" element={<FAQHub />} />

--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -19,7 +19,7 @@ const Header = () => {
   }, []);
 
   const navigationItems = [
-    { name: 'Início', path: '/homepage', icon: 'Home' },
+    { name: 'Início', path: '/', icon: 'Home' },
     { name: 'Áreas de Atuação', path: '/practice-areas-overview', icon: 'Scale' },
     { name: 'Sobre Marcelo', path: '/about-marcelo-ba-a', icon: 'User' },
     { name: 'FAQ', path: '/faq-hub', icon: 'HelpCircle' },
@@ -48,8 +48,8 @@ const Header = () => {
       <div className="max-w-7xl mx-auto">
         <div className="flex items-center justify-between h-16 lg:h-20 px-4 lg:px-6">
           {/* Logo */}
-          <Link 
-            to="/homepage" 
+          <Link
+            to="/"
             className="flex items-center space-x-3 group"
             onClick={closeMenu}
           >

--- a/src/pages/practice-areas-overview/index.jsx
+++ b/src/pages/practice-areas-overview/index.jsx
@@ -323,7 +323,7 @@ const PracticeAreasOverview = () => {
               <div>
                 <h4 className="font-inter font-semibold text-lg mb-4">Links Rápidos</h4>
                 <ul className="space-y-2">
-                  <li><a href="/homepage" className="text-white/80 hover:text-white font-inter text-sm transition-colors duration-200">Início</a></li>
+                  <li><a href="/" className="text-white/80 hover:text-white font-inter text-sm transition-colors duration-200">Início</a></li>
                   <li><a href="/about-marcelo-ba-a" className="text-white/80 hover:text-white font-inter text-sm transition-colors duration-200">Sobre Marcelo</a></li>
                   <li><a href="/faq-hub" className="text-white/80 hover:text-white font-inter text-sm transition-colors duration-200">FAQ</a></li>
                   <li><a href="/contact-consultation-hub" className="text-white/80 hover:text-white font-inter text-sm transition-colors duration-200">Contato</a></li>


### PR DESCRIPTION
## Summary
- Route the root path to the Homepage component so the site opens on Início instead of Sobre Marcelo
- Update navigation links and quick links to point to the new home path

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a647490c88832cb94230ee6bc6dc0e