### PR TITLE
Add complete OAB identification across site

### DIFF
--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -63,7 +63,7 @@ const Header = () => {
             </div>
             <div className="hidden sm:block">
               <h1 className="font-lora font-semibold text-lg lg:text-xl text-brand-primary leading-tight">
-                Marcelo Baía
+                {CONTACT.oab}
               </h1>
               <p className="text-xs lg:text-sm text-text-secondary font-inter font-light -mt-1">
                 Advocacia

--- a/src/config/contact.js
+++ b/src/config/contact.js
@@ -8,7 +8,7 @@ export const CONTACT = {
     text: 'marcelobaiaadvogado@gmail.com',
     href: 'mailto:marcelobaiaadvogado@gmail.com'
   },
-  oab: 'OAB/MT 14.159-B',
+  oab: 'Marcelo Baía — OAB/MT 14.159-B',
   address: 'Rua Tiradentes, 1888 – Centro, Rondonópolis-MT – CEP 78.700-028',
   schedule: 'Atendimento mediante agendamento. Atendimento via WhatsApp é em tempo integral.'
 };

--- a/src/pages/about-marcelo-ba-a/components/ContactSection.jsx
+++ b/src/pages/about-marcelo-ba-a/components/ContactSection.jsx
@@ -136,7 +136,7 @@ const ContactSection = () => {
                 <p>📍 Rua Tiradentes, 1888 – Centro, CEP 78.700-028</p>
                 <p>📞 (66) 99911-1314</p>
                 <p>✉️ marcelobaiaadvogado@gmail.com</p>
-                <p>🆔 OAB/MT 14.159-B</p>
+                <p>🆔 Marcelo Baía — OAB/MT 14.159-B</p>
                 <p>🕒 Atendimento mediante agendamento. Atendimento via WhatsApp é em tempo integral.</p>
               </div>
             </div>

--- a/src/pages/about-marcelo-ba-a/components/CredentialsSection.jsx
+++ b/src/pages/about-marcelo-ba-a/components/CredentialsSection.jsx
@@ -25,7 +25,7 @@ const CredentialsSection = () => {
 
   const certifications = [
     {
-      title: "OAB/MT 14.159-B",
+      title: "Marcelo Baía — OAB/MT 14.159-B",
       description: "Inscrito e ativo na Ordem dos Advogados do Brasil - Seção Mato Grosso",
       icon: "Scale",
       status: "Ativo desde 2015"

--- a/src/pages/about-marcelo-ba-a/components/HeroSection.jsx
+++ b/src/pages/about-marcelo-ba-a/components/HeroSection.jsx
@@ -10,7 +10,7 @@ const HeroSection = ({ onContactClick, onWhatsAppClick }) => {
           {/* Content */}
           <div className="order-2 lg:order-1">
             <div className="inline-flex items-center px-4 py-2 bg-brand-accent/10 rounded-full text-brand-accent text-sm font-medium mb-6">
-              <span>OAB/MT 14.159-B • Advocacia desde 2015</span>
+              <span>Marcelo Baía — OAB/MT 14.159-B • Advocacia desde 2015</span>
             </div>
             
             <h1 className="font-lora text-4xl lg:text-5xl xl:text-6xl font-bold text-brand-primary mb-6 leading-tight">
@@ -73,7 +73,7 @@ const HeroSection = ({ onContactClick, onWhatsAppClick }) => {
                     <span className="text-brand-accent font-bold text-lg">MB</span>
                   </div>
                   <div>
-                    <h3 className="font-semibold text-brand-primary">OAB/MT 14.159-B</h3>
+                    <h3 className="font-semibold text-brand-primary">Marcelo Baía — OAB/MT 14.159-B</h3>
                     <p className="text-sm text-text-secondary">Ativo desde 2015</p>
                   </div>
                 </div>

--- a/src/pages/about-marcelo-ba-a/index.jsx
+++ b/src/pages/about-marcelo-ba-a/index.jsx
@@ -99,7 +99,7 @@ const AboutMarceloBaia = () => {
                   Atendimento humanizado e comunicação transparente.
                 </p>
                 <p className="text-slate-400 text-xs">
-                  OAB/MT 14.159-B
+                  Marcelo Baía — OAB/MT 14.159-B
                 </p>
               </div>
 

--- a/src/pages/contact-consultation-hub/components/TrustSignals.jsx
+++ b/src/pages/contact-consultation-hub/components/TrustSignals.jsx
@@ -6,7 +6,7 @@ const TrustSignals = () => {
   const credentials = [
     {
       icon: 'Award',
-      title: 'OAB/MT 14.159-B',
+      title: 'Marcelo Baía — OAB/MT 14.159-B',
       description: 'Registro ativo na Ordem dos Advogados do Brasil'
     },
     {

--- a/src/pages/homepage/components/ContactSection.jsx
+++ b/src/pages/homepage/components/ContactSection.jsx
@@ -125,7 +125,7 @@ const ContactSection = () => {
               </h4>
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
-                  <span className="text-slate-600">OAB/MT 14.159-B</span>
+                  <span className="text-slate-600">Marcelo Baía — OAB/MT 14.159-B</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-slate-600">Endereço</span>

--- a/src/pages/homepage/components/HeroSection.jsx
+++ b/src/pages/homepage/components/HeroSection.jsx
@@ -38,7 +38,7 @@ const HeroSection = () => {
             {/* Trust Badge */}
             <div className="inline-flex items-center space-x-2 bg-white/80 backdrop-blur-sm px-4 py-2 rounded-full border border-slate-200 shadow-sm">
               <Icon name="Shield" size={16} className="text-indigo-600" />
-              <span className="text-sm font-medium text-slate-700">OAB/MT 14.159-B</span>
+              <span className="text-sm font-medium text-slate-700">Marcelo Baía — OAB/MT 14.159-B</span>
             </div>
 
             {/* Main Headline */}

--- a/src/pages/homepage/index.jsx
+++ b/src/pages/homepage/index.jsx
@@ -77,7 +77,7 @@ const Homepage = () => {
             <div className="space-y-4">
               <h4 className="font-semibold text-white">Informações</h4>
               <div className="space-y-2 text-sm text-slate-400">
-                <p>OAB/MT 14.159-B</p>
+                <p>Marcelo Baía — OAB/MT 14.159-B</p>
                 <p>CNPJ: 12.345.678/0001-90</p>
                 <p>Registro profissional ativo</p>
               </div>

--- a/src/pages/individual-practice-area-pages/components/PracticeAreaHero.jsx
+++ b/src/pages/individual-practice-area-pages/components/PracticeAreaHero.jsx
@@ -98,7 +98,7 @@ const PracticeAreaHero = ({ practiceArea, onWhatsAppClick, onCallClick }) => {
             <div className="flex items-center space-x-6 mt-8 pt-8 border-t border-white/20">
               <div className="flex items-center space-x-2">
                 <Icon name="CheckCircle" size={20} color="white" className="opacity-80" />
-                <span className="text-white/80 font-inter text-sm">OAB/MT 14.159-B</span>
+                <span className="text-white/80 font-inter text-sm">Marcelo Baía — OAB/MT 14.159-B</span>
               </div>
               <div className="flex items-center space-x-2">
                 <Icon name="Clock" size={20} color="white" className="opacity-80" />

--- a/src/pages/individual-practice-area-pages/index.jsx
+++ b/src/pages/individual-practice-area-pages/index.jsx
@@ -143,7 +143,7 @@ const IndividualPracticeAreaPages = () => {
                 <h3 className="font-lora font-semibold text-xl mb-4">Informações Legais</h3>
                 <div className="space-y-2">
                   <p className="font-inter text-slate-300 text-sm">
-                    OAB/MT 14.159-B
+                    Marcelo Baía — OAB/MT 14.159-B
                   </p>
                   <p className="font-inter text-slate-300 text-sm">
                     Atendimento mediante agendamento


### PR DESCRIPTION
## Summary
- show Marcelo Baía's full OAB identification in header and site sections
- replace standalone OAB number with "Marcelo Baía — OAB/MT 14.159-B" across pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build -- --outDir=/tmp/dist`


------
https://chatgpt.com/codex/tasks/task_b_68a703f0d7d8832ca4aba2f8e508c2a3