### PR TITLE
Add privacy disclaimers near WhatsApp CTAs

### DIFF
--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -88,36 +88,41 @@ const Header = () => {
           </nav>
 
           {/* Desktop CTA Buttons */}
-          <div className="hidden lg:flex items-center space-x-3">
-            <Button
-              asChild
-              variant="outline"
-              size="sm"
-              iconName="Phone"
-              iconPosition="left"
-              iconSize={16}
-              className="text-brand-accent border-brand-accent hover:bg-brand-accent hover:text-white"
-            >
-              <a href={phoneLink} aria-label={`Ligar para ${CONTACT.phone.display}`}>{CONTACT.phone.display}</a>
-            </Button>
-            <Button
-              asChild
-              variant="default"
-              size="sm"
-              iconName="MessageCircle"
-              iconPosition="left"
-              iconSize={16}
-              className="bg-brand-accent hover:bg-brand-accent/90 text-white shadow-brand"
-            >
-              <a
-                href={whatsappLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Conversar via WhatsApp"
+          <div className="hidden lg:flex flex-col items-end space-y-1">
+            <div className="flex items-center space-x-3">
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+                iconName="Phone"
+                iconPosition="left"
+                iconSize={16}
+                className="text-brand-accent border-brand-accent hover:bg-brand-accent hover:text-white"
               >
-                WhatsApp
-              </a>
-            </Button>
+                <a href={phoneLink} aria-label={`Ligar para ${CONTACT.phone.display}`}>{CONTACT.phone.display}</a>
+              </Button>
+              <Button
+                asChild
+                variant="default"
+                size="sm"
+                iconName="MessageCircle"
+                iconPosition="left"
+                iconSize={16}
+                className="bg-brand-accent hover:bg-brand-accent/90 text-white shadow-brand"
+              >
+                <a
+                  href={whatsappLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Conversar via WhatsApp"
+                >
+                  WhatsApp
+                </a>
+              </Button>
+            </div>
+            <p className="text-xs text-text-secondary">
+              Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+            </p>
           </div>
 
           {/* Mobile Menu Button */}
@@ -189,6 +194,9 @@ const Header = () => {
                   Conversar no WhatsApp
                 </a>
               </Button>
+              <p className="text-xs text-text-secondary">
+                Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+              </p>
             </div>
           </div>
         </div>

--- a/src/pages/about-marcelo-ba-a/components/ContactSection.jsx
+++ b/src/pages/about-marcelo-ba-a/components/ContactSection.jsx
@@ -120,6 +120,11 @@ const ContactSection = () => {
                       >
                         {method?.action}
                       </Button>
+                      {method?.title === 'WhatsApp' && (
+                        <p className="mt-2 text-xs text-text-secondary">
+                          Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+                        </p>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/pages/about-marcelo-ba-a/index.jsx
+++ b/src/pages/about-marcelo-ba-a/index.jsx
@@ -110,6 +110,9 @@ const AboutMarceloBaia = () => {
                   <p>📍 Rua Tiradentes, 1888 – Centro, Rondonópolis-MT – CEP 78.700-028</p>
                   <p>📞 <a href="tel:+5566999111314" className="text-slate-300">(66) 99911-1314</a></p>
                   <p>💬 <a href="https://wa.me/5566999111314" target="_blank" rel="noopener noreferrer" className="text-slate-300">(66) 99911-1314</a></p>
+                  <p className="text-xs text-slate-400 mt-1">
+                    Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+                  </p>
                   <p>✉️ <a href="mailto:marcelobaiaadvogado@gmail.com" className="text-slate-300">marcelobaiaadvogado@gmail.com</a></p>
                   <p>🕒 Atendimento mediante agendamento. Atendimento via WhatsApp é em tempo integral.</p>
                 </div>

--- a/src/pages/contact-consultation-hub/components/ContactMethods.jsx
+++ b/src/pages/contact-consultation-hub/components/ContactMethods.jsx
@@ -96,21 +96,26 @@ const ContactMethods = ({ onWhatsAppClick, onPhoneClick, onEmailClick }) => {
                   {method?.details}
                 </p>
                 
-                <Button
-                  variant="default"
-                  onClick={method?.action}
-                  iconName={method?.icon}
-                  iconPosition="left"
-                  iconSize={18}
-                  fullWidth
-                  className={`${method?.buttonColor} text-white shadow-md`}
-                >
-                  {method?.buttonText}
-                </Button>
+                  <Button
+                    variant="default"
+                    onClick={method?.action}
+                    iconName={method?.icon}
+                    iconPosition="left"
+                    iconSize={18}
+                    fullWidth
+                    className={`${method?.buttonColor} text-white shadow-md`}
+                  >
+                    {method?.buttonText}
+                  </Button>
+                  {method?.id === 'whatsapp' && (
+                    <p className="mt-2 text-xs text-slate-600">
+                      Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+                    </p>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
 
         <div className="mt-12 text-center">
           <div className="inline-flex items-center gap-2 px-4 py-2 bg-amber-50 text-amber-800 rounded-full text-sm font-medium">

--- a/src/pages/contact-consultation-hub/index.jsx
+++ b/src/pages/contact-consultation-hub/index.jsx
@@ -68,6 +68,9 @@ const ContactConsultationHub = () => {
             (66) 99911-1314
           </button>
         </div>
+        <p className="mt-2 text-xs text-slate-600 text-center">
+          Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+        </p>
       </div>
     </div>
   );

--- a/src/pages/faq-hub/components/ContactCTA.jsx
+++ b/src/pages/faq-hub/components/ContactCTA.jsx
@@ -152,6 +152,9 @@ const ContactCTA = () => {
                   >
                     Conversar agora
                   </Button>
+                  <p className="mt-2 text-xs text-text-secondary">
+                    Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+                  </p>
                 </div>
               </div>
               

--- a/src/pages/faq-hub/components/FAQAccordion.jsx
+++ b/src/pages/faq-hub/components/FAQAccordion.jsx
@@ -54,6 +54,9 @@ const FAQAccordion = ({ faqs, searchTerm }) => {
         >
           Fazer Pergunta Personalizada
         </Button>
+        <p className="mt-2 text-xs text-text-secondary">
+          Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+        </p>
       </div>
     );
   }
@@ -140,6 +143,9 @@ const FAQAccordion = ({ faqs, searchTerm }) => {
                     (66) 99911-1314
                   </Button>
                 </div>
+                <p className="mt-2 text-xs text-text-secondary">
+                  Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+                </p>
               </div>
             </div>
           )}

--- a/src/pages/faq-hub/index.jsx
+++ b/src/pages/faq-hub/index.jsx
@@ -399,15 +399,18 @@ const FAQHub = () => {
                 <Icon name="MessageCircle" size={20} />
                 <span>Conversar no WhatsApp</span>
               </button>
-              
+
               <button
                 onClick={() => window.location.href = 'tel:+5566999111314'}
-                className="flex items-center justify-center space-x-3 px-8 py-4 bg-white/10 text-white border border-white/20 rounded-xl font-inter font-semibold hover:bg-white/20 transition-all duration-300"
+                className="flex items-center justify-center space-x-3 px-8 py-4 bg-white/10 text-white border border-white/20 rounded-xl font-inter font-semibold hover:bg-white/20 transition-all duração-300"
               >
                 <Icon name="Phone" size={20} />
                 <span>Ligar Agora</span>
               </button>
             </div>
+            <p className="mt-4 text-xs text-white/80">
+              Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+            </p>
           </div>
         </section>
       </div>

--- a/src/pages/homepage/components/ContactSection.jsx
+++ b/src/pages/homepage/components/ContactSection.jsx
@@ -115,6 +115,9 @@ const ContactSection = () => {
                   </button>
                 ))}
               </div>
+              <p className="mt-2 text-xs text-slate-500">
+                Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+              </p>
             </div>
 
             {/* Office Hours */}
@@ -222,6 +225,9 @@ const ContactSection = () => {
               </Button>
 
               <p className="text-xs text-slate-500 text-center">
+                Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+              </p>
+              <p className="text-xs text-slate-500 text-center mt-1">
                 Ao enviar, você concorda com nossa política de privacidade e proteção de dados.
               </p>
             </form>

--- a/src/pages/homepage/components/FAQPreviewSection.jsx
+++ b/src/pages/homepage/components/FAQPreviewSection.jsx
@@ -101,23 +101,26 @@ const FAQPreviewSection = () => {
               </p>
             </div>
             
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-                to="/faq-hub"
-                className="inline-flex items-center space-x-2 bg-slate-100 hover:bg-slate-200 text-slate-700 px-6 py-3 rounded-lg font-medium transition-colors duration-300"
-              >
-                <Icon name="Search" size={18} />
-                <span>Ver todas as perguntas</span>
-              </Link>
-              
-              <button
-                onClick={() => window.open('https://wa.me/5566999111314', '_blank')}
-                className="inline-flex items-center space-x-2 bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded-lg font-medium transition-colors duration-300"
-              >
-                <Icon name="MessageCircle" size={18} />
-                <span>Fazer pergunta</span>
-              </button>
-           </div>
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <Link
+                  to="/faq-hub"
+                  className="inline-flex items-center space-x-2 bg-slate-100 hover:bg-slate-200 text-slate-700 px-6 py-3 rounded-lg font-medium transition-colors duration-300"
+                >
+                  <Icon name="Search" size={18} />
+                  <span>Ver todas as perguntas</span>
+                </Link>
+
+                <button
+                  onClick={() => window.open('https://wa.me/5566999111314', '_blank')}
+                  className="inline-flex items-center space-x-2 bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded-lg font-medium transition-colors duration-300"
+                >
+                  <Icon name="MessageCircle" size={18} />
+                  <span>Fazer pergunta</span>
+                </button>
+             </div>
+             <p className="mt-2 text-xs text-slate-600">
+               Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+             </p>
          </div>
        </div>
      </div>

--- a/src/pages/homepage/components/HeroSection.jsx
+++ b/src/pages/homepage/components/HeroSection.jsx
@@ -95,6 +95,9 @@ const HeroSection = () => {
                 (66) 99911-1314
               </Button>
             </div>
+            <p className="mt-2 text-xs text-slate-600">
+              Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+            </p>
           </div>
 
           {/* Right Column - Quick Consultation Form */}
@@ -163,6 +166,9 @@ const HeroSection = () => {
 
                 <p className="text-xs text-slate-500 text-center">
                   Resposta garantida em até 2 horas úteis
+                </p>
+                <p className="text-xs text-slate-500 text-center mt-1">
+                  Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
                 </p>
               </form>
             </div>

--- a/src/pages/homepage/components/StickyCTABar.jsx
+++ b/src/pages/homepage/components/StickyCTABar.jsx
@@ -69,31 +69,36 @@ const StickyCTABar = () => {
             </div>
 
             {/* Right - CTA Buttons */}
-            <div className="flex items-center space-x-3">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handlePhoneClick}
-                iconName="Phone"
-                iconPosition="left"
-                iconSize={16}
-                className="hidden sm:inline-flex text-slate-700 border-slate-300 hover:bg-slate-50"
-              >
-                (66) 99911-1314
-              </Button>
-              
-              <Button
-                variant="default"
-                size="sm"
-                onClick={handleWhatsAppClick}
-                iconName="MessageCircle"
-                iconPosition="left"
-                iconSize={16}
-                className="bg-indigo-600 hover:bg-indigo-700 text-white shadow-lg"
-              >
-                <span className="hidden sm:inline">WhatsApp</span>
-                <span className="sm:hidden">Conversar</span>
-              </Button>
+            <div className="flex flex-col items-end space-y-1">
+              <div className="flex items-center space-x-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handlePhoneClick}
+                  iconName="Phone"
+                  iconPosition="left"
+                  iconSize={16}
+                  className="hidden sm:inline-flex text-slate-700 border-slate-300 hover:bg-slate-50"
+                >
+                  (66) 99911-1314
+                </Button>
+
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={handleWhatsAppClick}
+                  iconName="MessageCircle"
+                  iconPosition="left"
+                  iconSize={16}
+                  className="bg-indigo-600 hover:bg-indigo-700 text-white shadow-lg"
+                >
+                  <span className="hidden sm:inline">WhatsApp</span>
+                  <span className="sm:hidden">Conversar</span>
+                </Button>
+              </div>
+              <p className="text-[10px] text-slate-600 text-right">
+                Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+              </p>
             </div>
           </div>
         </div>

--- a/src/pages/homepage/components/TestimonialsSection.jsx
+++ b/src/pages/homepage/components/TestimonialsSection.jsx
@@ -143,22 +143,25 @@ const TestimonialsSection = () => {
               <p className="text-indigo-100 mb-6">
                 Agende uma consulta gratuita e descubra como posso ajudar você a alcançar os melhores resultados.
               </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <button
-                  onClick={() => window.open('https://wa.me/5566999111314', '_blank')}
-                  className="inline-flex items-center space-x-2 bg-white text-indigo-600 px-6 py-3 rounded-lg font-medium hover:bg-slate-50 transition-colors duration-300"
-                >
-                  <Icon name="MessageCircle" size={18} />
-                  <span>Agendar consulta</span>
-                </button>
-                <button
-                  onClick={() => window.location.href = 'tel:+5566999111314'}
-                  className="inline-flex items-center space-x-2 bg-transparent border-2 border-white text-white px-6 py-3 rounded-lg font-medium hover:bg-white hover:text-indigo-600 transition-all duration-300"
-                >
-                  <Icon name="Phone" size={18} />
-                  <span>(66) 99911-1314</span>
-                </button>
-              </div>
+                <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                  <button
+                    onClick={() => window.open('https://wa.me/5566999111314', '_blank')}
+                    className="inline-flex items-center space-x-2 bg-white text-indigo-600 px-6 py-3 rounded-lg font-medium hover:bg-slate-50 transition-colors duration-300"
+                  >
+                    <Icon name="MessageCircle" size={18} />
+                    <span>Agendar consulta</span>
+                  </button>
+                  <button
+                    onClick={() => window.location.href = 'tel:+5566999111314'}
+                    className="inline-flex items-center space-x-2 bg-transparent border-2 border-white text-white px-6 py-3 rounded-lg font-medium hover:bg-white hover:text-indigo-600 transition-all duration-300"
+                  >
+                    <Icon name="Phone" size={18} />
+                    <span>(66) 99911-1314</span>
+                  </button>
+                </div>
+                <p className="mt-2 text-xs text-white/80">
+                  Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+                </p>
             </div>
           </div>
         </div>

--- a/src/pages/individual-practice-area-pages/components/ContactCTA.jsx
+++ b/src/pages/individual-practice-area-pages/components/ContactCTA.jsx
@@ -97,26 +97,29 @@ const ContactCTA = ({ practiceArea }) => {
               Recebemos sua solicitação e entraremos em contato em até 24 horas. 
               Para questões urgentes, utilize nossos canais diretos.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button
-                variant="default"
-                onClick={handleWhatsAppClick}
-                iconName="MessageCircle"
-                iconPosition="left"
-                className="bg-green-600 hover:bg-green-700"
-              >
-                WhatsApp Direto
-              </Button>
-              <Button
-                variant="outline"
-                onClick={handlePhoneClick}
-                iconName="Phone"
-                iconPosition="left"
-                className="border-green-600 text-green-600 hover:bg-green-50"
-              >
-                (66) 99911-1314
-              </Button>
-            </div>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button
+              variant="default"
+              onClick={handleWhatsAppClick}
+              iconName="MessageCircle"
+              iconPosition="left"
+              className="bg-green-600 hover:bg-green-700"
+            >
+              WhatsApp Direto
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handlePhoneClick}
+              iconName="Phone"
+              iconPosition="left"
+              className="border-green-600 text-green-600 hover:bg-green-50"
+            >
+              (66) 99911-1314
+            </Button>
+          </div>
+          <p className="mt-4 text-xs text-slate-600">
+            Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+          </p>
           </div>
         </div>
       </section>
@@ -195,6 +198,9 @@ const ContactCTA = ({ practiceArea }) => {
                 Ligar Agora
               </Button>
             </div>
+            <p className="mt-2 text-xs text-white/70">
+              Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+            </p>
           </div>
 
           {/* Contact Form */}

--- a/src/pages/individual-practice-area-pages/components/ContextualFAQ.jsx
+++ b/src/pages/individual-practice-area-pages/components/ContextualFAQ.jsx
@@ -156,28 +156,31 @@ const ContextualFAQ = ({ practiceArea }) => {
             <p className="font-inter text-slate-600 mb-6">
               Entre em contato conosco. Teremos prazer em esclarecer sua questão específica.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <a
-                href="https://wa.me/5566999111314"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center px-6 py-3 bg-indigo-600 text-white font-semibold rounded-lg hover:bg-indigo-700 transition-colors duration-200"
-              >
-                <Icon name="MessageCircle" size={20} className="mr-2" />
-                Perguntar via WhatsApp
-              </a>
-              <a
-                href="tel:+5566999111314"
-                className="inline-flex items-center justify-center px-6 py-3 border border-slate-300 text-slate-700 font-semibold rounded-lg hover:bg-slate-50 transition-colors duração-200"
-              >
-                <Icon name="Phone" size={20} className="mr-2" />
-                (66) 99911-1314
-              </a>
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <a
+                  href="https://wa.me/5566999111314"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center px-6 py-3 bg-indigo-600 text-white font-semibold rounded-lg hover:bg-indigo-700 transition-colors duration-200"
+                >
+                  <Icon name="MessageCircle" size={20} className="mr-2" />
+                  Perguntar via WhatsApp
+                </a>
+                <a
+                  href="tel:+5566999111314"
+                  className="inline-flex items-center justify-center px-6 py-3 border border-slate-300 text-slate-700 font-semibold rounded-lg hover:bg-slate-50 transition-colors duração-200"
+                >
+                  <Icon name="Phone" size={20} className="mr-2" />
+                  (66) 99911-1314
+                </a>
+              </div>
+              <p className="mt-2 text-xs text-slate-600">
+                Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+              </p>
             </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 };
 

--- a/src/pages/individual-practice-area-pages/components/ServiceBreakdown.jsx
+++ b/src/pages/individual-practice-area-pages/components/ServiceBreakdown.jsx
@@ -201,19 +201,22 @@ const ServiceBreakdown = ({ practiceArea }) => {
                 href="https://wa.me/5566999111314"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center justify-center px-6 py-3 bg-white text-slate-900 font-semibold rounded-lg hover:bg-slate-100 transition-colors duração-200"
+                className="inline-flex items-center justify-center px-6 py-3 bg-white text-slate-900 font-semibold rounded-lg hover:bg-slate-100 transition-colors duration-200"
               >
                 <Icon name="MessageCircle" size={20} className="mr-2" />
                 Consulta via WhatsApp
               </a>
               <a
                 href="tel:+5566999111314"
-                className="inline-flex items-center justify-center px-6 py-3 border border-white/30 text-white font-semibold rounded-lg hover:bg-white/10 transition-colors duração-200"
+                className="inline-flex items-center justify-center px-6 py-3 border border-white/30 text-white font-semibold rounded-lg hover:bg-white/10 transition-colors duration-200"
               >
                 <Icon name="Phone" size={20} className="mr-2" />
                 (66) 99911-1314
               </a>
             </div>
+            <p className="mt-2 text-xs text-slate-300">
+              Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+            </p>
           </div>
         </div>
       </div>

--- a/src/pages/individual-practice-area-pages/index.jsx
+++ b/src/pages/individual-practice-area-pages/index.jsx
@@ -121,6 +121,9 @@ const IndividualPracticeAreaPages = () => {
                   <p className="font-inter text-slate-300">
                     💬 <a href="https://wa.me/5566999111314" target="_blank" rel="noopener noreferrer" className="text-slate-300">(66) 99911-1314</a>
                   </p>
+                  <p className="font-inter text-xs text-slate-400 mt-1">
+                    Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+                  </p>
                   <p className="font-inter text-slate-300">
                     ✉️ <a href="mailto:marcelobaiaadvogado@gmail.com" className="text-slate-300">marcelobaiaadvogado@gmail.com</a>
                   </p>

--- a/src/pages/practice-areas-overview/components/ConsultationWidget.jsx
+++ b/src/pages/practice-areas-overview/components/ConsultationWidget.jsx
@@ -122,37 +122,40 @@ const ConsultationWidget = () => {
             </div>
 
             {/* Booking Actions */}
-            <div className="mt-8 pt-8 border-t border-white/20">
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <Button
-                  variant="default"
-                  onClick={handleBooking}
-                  iconName="MessageCircle"
-                  iconPosition="left"
-                  iconSize={18}
-                  className="bg-white text-brand-primary hover:bg-white/90 font-medium px-8 py-3"
-                >
-                  Confirmar via WhatsApp
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => window.location.href = 'tel:+5566999111314'}
-                  iconName="Phone"
-                  iconPosition="left"
-                  iconSize={18}
-                  className="border-white text-white hover:bg-white hover:text-brand-primary font-medium px-8 py-3"
-                >
-                  (66) 99911-1314
-                </Button>
-              </div>
-              
-              <div className="text-center mt-6">
-                <p className="text-sm text-white/80 font-inter">
-                  <Icon name="Shield" size={14} className="inline mr-1" />
-                  Consulta inicial com valor acessível • Sigilo profissional garantido
+              <div className="mt-8 pt-8 border-t border-white/20">
+                <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                  <Button
+                    variant="default"
+                    onClick={handleBooking}
+                    iconName="MessageCircle"
+                    iconPosition="left"
+                    iconSize={18}
+                    className="bg-white text-brand-primary hover:bg-white/90 font-medium px-8 py-3"
+                  >
+                    Confirmar via WhatsApp
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => window.location.href = 'tel:+5566999111314'}
+                    iconName="Phone"
+                    iconPosition="left"
+                    iconSize={18}
+                    className="border-white text-white hover:bg-white hover:text-brand-primary font-medium px-8 py-3"
+                  >
+                    (66) 99911-1314
+                  </Button>
+                </div>
+                <p className="mt-2 text-xs text-white/80 text-center">
+                  Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
                 </p>
+
+                <div className="text-center mt-6">
+                  <p className="text-sm text-white/80 font-inter">
+                    <Icon name="Shield" size={14} className="inline mr-1" />
+                    Consulta inicial com valor acessível • Sigilo profissional garantido
+                  </p>
+                </div>
               </div>
-            </div>
           </div>
         </div>
       </div>

--- a/src/pages/practice-areas-overview/components/FAQSection.jsx
+++ b/src/pages/practice-areas-overview/components/FAQSection.jsx
@@ -110,27 +110,30 @@ const FAQSection = () => {
         </div>
 
         {/* CTA */}
-        <div className="text-center mt-12">
-          <p className="text-text-secondary font-inter mb-6">
-            Não encontrou a resposta que procurava?
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <button
-              onClick={() => window.open('https://wa.me/5566999111314', '_blank')}
-              className="inline-flex items-center justify-center px-6 py-3 bg-brand-accent hover:bg-brand-accent/90 text-white font-inter font-medium rounded-lg transition-colors duração-200"
-            >
-              <Icon name="MessageCircle" size={18} className="mr-2" />
-              Perguntar no WhatsApp
-            </button>
-            <button
-              onClick={() => window.location.href = 'tel:+5566999111314'}
-              className="inline-flex items-center justify-center px-6 py-3 border border-brand-accent text-brand-accent hover:bg-brand-accent hover:text-white font-inter font-medium rounded-lg transition-colors duração-200"
-            >
-              <Icon name="Phone" size={18} className="mr-2" />
-              (66) 99911-1314
-            </button>
+          <div className="text-center mt-12">
+            <p className="text-text-secondary font-inter mb-6">
+              Não encontrou a resposta que procurava?
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <button
+                onClick={() => window.open('https://wa.me/5566999111314', '_blank')}
+                className="inline-flex items-center justify-center px-6 py-3 bg-brand-accent hover:bg-brand-accent/90 text-white font-inter font-medium rounded-lg transition-colors duração-200"
+              >
+                <Icon name="MessageCircle" size={18} className="mr-2" />
+                Perguntar no WhatsApp
+              </button>
+              <button
+                onClick={() => window.location.href = 'tel:+5566999111314'}
+                className="inline-flex items-center justify-center px-6 py-3 border border-brand-accent text-brand-accent hover:bg-brand-accent hover:text-white font-inter font-medium rounded-lg transition-colors duração-200"
+              >
+                <Icon name="Phone" size={18} className="mr-2" />
+                (66) 99911-1314
+              </button>
+            </div>
+            <p className="mt-2 text-xs text-text-secondary">
+              Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+            </p>
           </div>
-        </div>
       </div>
     </section>
   );

--- a/src/pages/practice-areas-overview/components/PracticeAreaCard.jsx
+++ b/src/pages/practice-areas-overview/components/PracticeAreaCard.jsx
@@ -100,7 +100,7 @@ const PracticeAreaCard = ({
           >
             {isExpanded ? 'Ver Menos' : 'Ver Detalhes'}
           </Button>
-          
+
           <Button
             variant="default"
             onClick={handleWhatsAppClick}
@@ -112,6 +112,9 @@ const PracticeAreaCard = ({
             Consultar
           </Button>
         </div>
+        <p className="mt-2 text-xs text-text-secondary">
+          Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+        </p>
 
         {/* Quick Consultation */}
         <div className="mt-4 pt-4 border-t border-border">
@@ -126,6 +129,9 @@ const PracticeAreaCard = ({
           >
             Agendar Consulta Presencial
           </Button>
+          <p className="mt-2 text-xs text-text-secondary">
+            Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+          </p>
         </div>
       </div>
     </div>

--- a/src/pages/practice-areas-overview/components/PreventiveLegalSection.jsx
+++ b/src/pages/practice-areas-overview/components/PreventiveLegalSection.jsx
@@ -174,30 +174,33 @@ const PreventiveLegalSection = () => {
               de forma proativa e inteligente.
             </p>
             
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button
-                variant="default"
-                onClick={handlePreventiveConsultation}
-                iconName="Shield"
-                iconPosition="left"
-                iconSize={18}
-                className="bg-white text-brand-primary hover:bg-white/90 font-medium px-8 py-3"
-              >
-                Consultoria Preventiva
-              </Button>
-              <Button
-                variant="outline"
-                onClick={() => window.location.href = 'tel:+5566999111314'}
-                iconName="Phone"
-                iconPosition="left"
-                iconSize={18}
-                className="border-white text-white hover:bg-white hover:text-brand-primary font-medium px-8 py-3"
-              >
-                (66) 99911-1314
-              </Button>
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <Button
+                  variant="default"
+                  onClick={handlePreventiveConsultation}
+                  iconName="Shield"
+                  iconPosition="left"
+                  iconSize={18}
+                  className="bg-white text-brand-primary hover:bg-white/90 font-medium px-8 py-3"
+                >
+                  Consultoria Preventiva
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => window.location.href = 'tel:+5566999111314'}
+                  iconName="Phone"
+                  iconPosition="left"
+                  iconSize={18}
+                  className="border-white text-white hover:bg-white hover:text-brand-primary font-medium px-8 py-3"
+                >
+                  (66) 99911-1314
+                </Button>
+              </div>
+              <p className="mt-2 text-xs text-white/80">
+                Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+              </p>
             </div>
           </div>
-        </div>
       </div>
     </section>
   );

--- a/src/pages/practice-areas-overview/index.jsx
+++ b/src/pages/practice-areas-overview/index.jsx
@@ -173,6 +173,9 @@ const PracticeAreasOverview = () => {
                   (66) 99911-1314
                 </button>
               </div>
+              <p className="mt-2 text-xs text-white/80">
+                Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+              </p>
             </div>
           </div>
         </section>
@@ -317,6 +320,9 @@ const PracticeAreasOverview = () => {
                     <Icon name="Phone" size={20} />
                   </a>
                 </div>
+                <p className="mt-2 text-xs text-white/70">
+                  Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+                </p>
               </div>
 
               {/* Quick Links */}
@@ -345,6 +351,9 @@ const PracticeAreasOverview = () => {
                       (66) 99911-1314
                     </a>
                   </div>
+                  <p className="mt-2 text-xs text-white/70">
+                    Ao clicar, você será redirecionado ao WhatsApp. Seus dados serão tratados conforme nossa Política de Privacidade.
+                  </p>
                   <div className="flex items-center space-x-3">
                     <Icon name="Phone" size={16} className="text-brand-accent" />
                     <a href="tel:+5566999111314" className="text-white/80 font-inter text-sm">(66) 99911-1314</a>


### PR DESCRIPTION
## Summary
- add privacy notice near WhatsApp buttons in header and multiple sections
- replicate the notice across contact components and pages
- run build to ensure compilation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a703ed6010832ca7a2862bee8cd310