### PR TITLE
Add mandatory privacy consent checkbox to forms

### DIFF
--- a/src/pages/about-marcelo-ba-a/components/ContactSection.jsx
+++ b/src/pages/about-marcelo-ba-a/components/ContactSection.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
 import Input from '../../../components/ui/Input';
+import { Checkbox } from '../../../components/ui/Checkbox';
 
 const ContactSection = () => {
   const [formData, setFormData] = useState({
@@ -9,7 +10,8 @@ const ContactSection = () => {
     email: '',
     phone: '',
     subject: '',
-    message: ''
+    message: '',
+    consent: false
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -49,10 +51,10 @@ const ContactSection = () => {
   ];
 
   const handleInputChange = (e) => {
-    const { name, value } = e?.target;
+    const { name, value, type, checked } = e?.target;
     setFormData(prev => ({
       ...prev,
-      [name]: value
+      [name]: type === 'checkbox' ? checked : value
     }));
   };
 
@@ -68,7 +70,8 @@ const ContactSection = () => {
         email: '',
         phone: '',
         subject: '',
-        message: ''
+        message: '',
+        consent: false
       });
       setIsSubmitting(false);
     }, 2000);
@@ -207,6 +210,14 @@ const ContactSection = () => {
                   required
                 />
               </div>
+
+              <Checkbox
+                label="Autorizo o tratamento dos meus dados para contato e análise do meu caso, conforme a Política de Privacidade"
+                name="consent"
+                checked={formData?.consent}
+                onChange={handleInputChange}
+                required
+              />
 
               <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
                 <div className="flex items-start space-x-3">

--- a/src/pages/faq-hub/components/ContactCTA.jsx
+++ b/src/pages/faq-hub/components/ContactCTA.jsx
@@ -2,21 +2,23 @@ import React, { useState } from 'react';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
 import Input from '../../../components/ui/Input';
+import { Checkbox } from '../../../components/ui/Checkbox';
 
 const ContactCTA = () => {
   const [formData, setFormData] = useState({
     name: '',
     email: '',
-    question: ''
+    question: '',
+    consent: false
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
 
   const handleInputChange = (e) => {
-    const { name, value } = e?.target;
+    const { name, value, type, checked } = e?.target;
     setFormData(prev => ({
       ...prev,
-      [name]: value
+      [name]: type === 'checkbox' ? checked : value
     }));
   };
 
@@ -33,7 +35,7 @@ const ContactCTA = () => {
     // Reset form after 3 seconds
     setTimeout(() => {
       setIsSubmitted(false);
-      setFormData({ name: '', email: '', question: '' });
+      setFormData({ name: '', email: '', question: '', consent: false });
     }, 3000);
   };
 
@@ -112,6 +114,14 @@ const ContactCTA = () => {
                   className="w-full px-4 py-3 border border-border rounded-lg focus:ring-2 focus:ring-brand-accent focus:border-transparent resize-none"
                 />
               </div>
+
+              <Checkbox
+                label="Autorizo o tratamento dos meus dados para contato e análise do meu caso, conforme a Política de Privacidade"
+                name="consent"
+                checked={formData?.consent}
+                onChange={handleInputChange}
+                required
+              />
               
               <Button
                 type="submit"

--- a/src/pages/homepage/components/ContactSection.jsx
+++ b/src/pages/homepage/components/ContactSection.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
 import Input from '../../../components/ui/Input';
+import { Checkbox } from '../../../components/ui/Checkbox';
 
 const ContactSection = () => {
   const [formData, setFormData] = useState({
@@ -9,14 +10,15 @@ const ContactSection = () => {
     email: '',
     phone: '',
     subject: '',
-    message: ''
+    message: '',
+    consent: false
   });
 
   const handleInputChange = (e) => {
-    const { name, value } = e?.target;
+    const { name, value, type, checked } = e?.target;
     setFormData(prev => ({
       ...prev,
-      [name]: value
+      [name]: type === 'checkbox' ? checked : value
     }));
   };
 
@@ -207,6 +209,14 @@ const ContactSection = () => {
                   required
                 />
               </div>
+
+              <Checkbox
+                label="Autorizo o tratamento dos meus dados para contato e análise do meu caso, conforme a Política de Privacidade"
+                name="consent"
+                checked={formData?.consent}
+                onChange={handleInputChange}
+                required
+              />
 
               <Button
                 type="submit"

--- a/src/pages/homepage/components/HeroSection.jsx
+++ b/src/pages/homepage/components/HeroSection.jsx
@@ -2,19 +2,21 @@ import React, { useState } from 'react';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
 import Input from '../../../components/ui/Input';
+import { Checkbox } from '../../../components/ui/Checkbox';
 
 const HeroSection = () => {
   const [formData, setFormData] = useState({
     name: '',
     phone: '',
-    message: ''
+    message: '',
+    consent: false
   });
 
   const handleInputChange = (e) => {
-    const { name, value } = e?.target;
+    const { name, value, type, checked } = e?.target;
     setFormData(prev => ({
       ...prev,
-      [name]: value
+      [name]: type === 'checkbox' ? checked : value
     }));
   };
 
@@ -147,6 +149,14 @@ const HeroSection = () => {
                     required
                   />
                 </div>
+
+                <Checkbox
+                  label="Autorizo o tratamento dos meus dados para contato e análise do meu caso, conforme a Política de Privacidade"
+                  name="consent"
+                  checked={formData?.consent}
+                  onChange={handleInputChange}
+                  required
+                />
 
                 <Button
                   type="submit"

--- a/src/pages/individual-practice-area-pages/components/ContactCTA.jsx
+++ b/src/pages/individual-practice-area-pages/components/ContactCTA.jsx
@@ -3,6 +3,7 @@ import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
 import Input from '../../../components/ui/Input';
 import Select from '../../../components/ui/Select';
+import { Checkbox } from '../../../components/ui/Checkbox';
 
 const ContactCTA = ({ practiceArea }) => {
   const [formData, setFormData] = useState({
@@ -10,7 +11,8 @@ const ContactCTA = ({ practiceArea }) => {
     email: '',
     phone: '',
     urgency: '',
-    message: ''
+    message: '',
+    consent: false
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
@@ -37,10 +39,10 @@ const ContactCTA = ({ practiceArea }) => {
   };
 
   const handleInputChange = (e) => {
-    const { name, value } = e?.target;
+    const { name, value, type, checked } = e?.target;
     setFormData(prev => ({
       ...prev,
-      [name]: value
+      [name]: type === 'checkbox' ? checked : value
     }));
   };
 
@@ -69,7 +71,8 @@ const ContactCTA = ({ practiceArea }) => {
         email: '',
         phone: '',
         urgency: '',
-        message: ''
+        message: '',
+        consent: false
       });
     }, 3000);
   };
@@ -264,6 +267,14 @@ const ContactCTA = ({ practiceArea }) => {
                   required
                 />
               </div>
+
+              <Checkbox
+                label="Autorizo o tratamento dos meus dados para contato e análise do meu caso, conforme a Política de Privacidade"
+                name="consent"
+                checked={formData?.consent}
+                onChange={handleInputChange}
+                required
+              />
 
               <Button
                 type="submit"


### PR DESCRIPTION
## Summary
- Add reusable privacy consent checkbox to all main contact forms
- Require consent before form submission

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a703ec6be0832cac0f7762971fd672