### PR TITLE
refactor: update focus terminology in practice area pages

### DIFF
--- a/src/pages/about-marcelo-ba-a/components/HeroSection.jsx
+++ b/src/pages/about-marcelo-ba-a/components/HeroSection.jsx
@@ -61,9 +61,9 @@ const HeroSection = ({ onContactClick, onWhatsAppClick }) => {
               <div className="aspect-[4/5] rounded-2xl overflow-hidden shadow-2xl">
                 <Image
                   src="public\assets\images\Marcelo.png"
-                  alt="Marcelo Baía - Advogado especialista em Direito Civil, Consumidor, Família e Empresarial"
-                  className="w-full h-full object-cover"
-                />
+                    alt="Marcelo Baía - Advogado com foco em Direito Civil, Consumidor, Família e Empresarial"
+                    className="w-full h-full object-cover"
+                  />
               </div>
               
               {/* Floating credential card */}
@@ -77,9 +77,9 @@ const HeroSection = ({ onContactClick, onWhatsAppClick }) => {
                     <p className="text-sm text-text-secondary">Ativo desde 2015</p>
                   </div>
                 </div>
-                <p className="text-sm text-text-primary">
-                  Especialista em Direito Civil, Consumidor, Família e Empresarial
-                </p>
+                  <p className="text-sm text-text-primary">
+                    Foco em Direito Civil, Consumidor, Família e Empresarial
+                  </p>
               </div>
             </div>
           </div>

--- a/src/pages/about-marcelo-ba-a/index.jsx
+++ b/src/pages/about-marcelo-ba-a/index.jsx
@@ -22,20 +22,20 @@ const AboutMarceloBaia = () => {
 
   return (
     <>
-      <Helmet>
-        <title>Sobre Marcelo Baía - Advogado Especialista em Rondonópolis/MT</title>
-        <meta 
-          name="description" 
-          content="Conheça a trajetória profissional de Marcelo Baía, advogado especialista em Direito Civil, Consumidor, Família e Empresarial em Rondonópolis/MT. Mais de 8 anos de experiência com atendimento humanizado." 
-        />
-        <meta name="keywords" content="advogado rondonópolis, marcelo baía, direito civil, direito consumidor, direito família, direito empresarial, oab mt" />
-        <meta property="og:title" content="Sobre Marcelo Baía - Advogado Especialista em Rondonópolis/MT" />
-        <meta property="og:description" content="Conheça a trajetória profissional de Marcelo Baía, advogado especialista com mais de 8 anos de experiência em Rondonópolis/MT." />
-        <meta property="og:image" content="/assets/images/logo-512x512.png" />
-        <meta name="twitter:image" content="/assets/images/logo-512x512.png" />
-        <meta property="og:type" content="website" />
-        <link rel="canonical" href="https://marcelobaia.adv.br/about-marcelo-ba-a" />
-        <script type="application/ld+json">
+        <Helmet>
+          <title>Sobre Marcelo Baía - Advogado com foco em Direito Civil, Consumidor, Família e Empresarial em Rondonópolis/MT</title>
+          <meta
+            name="description"
+            content="Conheça a trajetória profissional de Marcelo Baía, advogado com foco em Direito Civil, Consumidor, Família e Empresarial em Rondonópolis/MT. Mais de 8 anos de experiência com atendimento humanizado."
+          />
+          <meta name="keywords" content="advogado rondonópolis, marcelo baía, direito civil, direito consumidor, direito família, direito empresarial, oab mt" />
+          <meta property="og:title" content="Sobre Marcelo Baía - Advogado com foco em Direito Civil, Consumidor, Família e Empresarial em Rondonópolis/MT" />
+          <meta property="og:description" content="Conheça a trajetória profissional de Marcelo Baía, advogado com foco em Direito Civil, Consumidor, Família e Empresarial e mais de 8 anos de experiência em Rondonópolis/MT." />
+          <meta property="og:image" content="/assets/images/logo-512x512.png" />
+          <meta name="twitter:image" content="/assets/images/logo-512x512.png" />
+          <meta property="og:type" content="website" />
+          <link rel="canonical" href="https://marcelobaia.adv.br/about-marcelo-ba-a" />
+          <script type="application/ld+json">
           {JSON.stringify({
             "@context": "https://schema.org",
             "@type": "LegalService",

--- a/src/pages/individual-practice-area-pages/index.jsx
+++ b/src/pages/individual-practice-area-pages/index.jsx
@@ -40,7 +40,7 @@ const IndividualPracticeAreaPages = () => {
 
   const getPageDescription = () => {
     const descriptions = {
-      civil: 'Especialista em Direito Civil em Rondonópolis/MT. Contratos, responsabilidade civil, direitos reais e questões patrimoniais com atendimento personalizado.',
+        civil: 'Foco em Direito Civil em Rondonópolis/MT. Contratos, responsabilidade civil, direitos reais e questões patrimoniais com atendimento personalizado.',
       consumer: 'Defesa do Consumidor em Rondonópolis/MT. Proteção contra práticas abusivas, vícios de produtos, serviços bancários e direitos do consumidor.',
       family: 'Direito de Família em Rondonópolis/MT. Divórcio, guarda, pensão alimentícia e questões familiares com atendimento humanizado e discreto.',
       business: 'Direito Empresarial em Rondonópolis/MT. Consultoria jurídica para empresas, contratos comerciais, recuperação judicial e compliance.'

--- a/src/pages/practice-areas-overview/index.jsx
+++ b/src/pages/practice-areas-overview/index.jsx
@@ -98,12 +98,12 @@ const PracticeAreasOverview = () => {
   return (
     <>
       <Helmet>
-        <title>Áreas de Atuação - Marcelo Baía Advocacia | Especialista em Direito Civil, Consumidor, Família e Empresarial</title>
-        <meta name="description" content="Conheça as áreas de especialização do escritório Marcelo Baía Advocacia: Direito Civil, Consumidor, Família e Empresarial. Atendimento humanizado em Rondonópolis/MT." />
+        <title>Áreas de Atuação - Marcelo Baía Advocacia | Foco em Direito Civil, Consumidor, Família e Empresarial</title>
+        <meta name="description" content="Conheça as áreas de atuação do escritório Marcelo Baía Advocacia: Direito Civil, Consumidor, Família e Empresarial. Atendimento humanizado em Rondonópolis/MT." />
         <meta name="keywords" content="advocacia, direito civil, direito consumidor, direito família, direito empresarial, Rondonópolis, Mato Grosso" />
         <link rel="canonical" href="https://marcelobaia.adv.br/practice-areas-overview" />
-        <meta property="og:title" content="Áreas de Atuação - Marcelo Baía Advocacia | Especialista em Direito Civil, Consumidor, Família e Empresarial" />
-        <meta property="og:description" content="Conheça as áreas de especialização do escritório Marcelo Baía Advocacia: Direito Civil, Consumidor, Família e Empresarial. Atendimento humanizado em Rondonópolis/MT." />
+        <meta property="og:title" content="Áreas de Atuação - Marcelo Baía Advocacia | Foco em Direito Civil, Consumidor, Família e Empresarial" />
+        <meta property="og:description" content="Conheça as áreas de atuação do escritório Marcelo Baía Advocacia: Direito Civil, Consumidor, Família e Empresarial. Atendimento humanizado em Rondonópolis/MT." />
         <meta property="og:image" content="/assets/images/logo-512x512.png" />
         <meta name="twitter:image" content="/assets/images/logo-512x512.png" />
         <meta property="og:type" content="website" />
@@ -153,7 +153,7 @@ const PracticeAreasOverview = () => {
               </h1>
               
               <p className="text-xl lg:text-2xl text-white/90 font-inter mb-8 leading-relaxed">
-                Expertise jurídica especializada para proteger seus direitos e interesses 
+                Atuação jurídica dedicada para proteger seus direitos e interesses
                 com atendimento humanizado e soluções eficazes
               </p>
               
@@ -182,7 +182,7 @@ const PracticeAreasOverview = () => {
           <div className="max-w-7xl mx-auto px-4 lg:px-6">
             <div className="text-center mb-16">
               <h2 className="font-lora font-semibold text-3xl lg:text-4xl text-brand-primary mb-4">
-                Especialidades Jurídicas
+                Focos Jurídicos
               </h2>
               <p className="text-lg text-text-secondary font-inter max-w-3xl mx-auto">
                 Cada área de atuação é tratada com expertise técnica e abordagem humanizada, 


### PR DESCRIPTION
## Summary
- replace specialty wording with "foco" or "atuação" across practice area pages
- adjust metadata and image alt text to emphasize focus areas

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a703e6e11c832c931a873e7982667b