### PR TITLE
Replace free consultation text with case evaluation messaging

### DIFF
--- a/src/pages/about-marcelo-ba-a/components/ContactSection.jsx
+++ b/src/pages/about-marcelo-ba-a/components/ContactSection.jsx
@@ -212,9 +212,9 @@ const ContactSection = () => {
                 <div className="flex items-start space-x-3">
                   <Icon name="Info" size={20} color="rgb(245 158 11)" className="flex-shrink-0 mt-0.5" />
                   <div className="text-sm text-amber-800">
-                    <p className="font-medium mb-1">Consulta Inicial Gratuita</p>
+                    <p className="font-medium mb-1">Fale com a equipe para uma avaliação do seu caso</p>
                     <p>
-                      A primeira consulta é gratuita e sem compromisso. Vamos analisar seu caso 
+                      Fale com a equipe para uma avaliação do seu caso. Vamos analisar as informações
                       e apresentar as melhores opções para sua situação.
                     </p>
                   </div>

--- a/src/pages/contact-consultation-hub/components/ContactMethods.jsx
+++ b/src/pages/contact-consultation-hub/components/ContactMethods.jsx
@@ -115,7 +115,7 @@ const ContactMethods = ({ onWhatsAppClick, onPhoneClick, onEmailClick }) => {
         <div className="mt-12 text-center">
           <div className="inline-flex items-center gap-2 px-4 py-2 bg-amber-50 text-amber-800 rounded-full text-sm font-medium">
             <Icon name="Info" size={16} />
-            <span>Primeira consulta gratuita para avaliação do caso</span>
+            <span>Fale com a equipe para uma avaliação do seu caso</span>
           </div>
         </div>
       </div>

--- a/src/pages/homepage/components/HeroSection.jsx
+++ b/src/pages/homepage/components/HeroSection.jsx
@@ -105,10 +105,10 @@ const HeroSection = () => {
                   <Icon name="Calendar" size={24} className="text-indigo-600" />
                 </div>
                 <h3 className="font-lora text-xl font-semibold text-slate-900 mb-2">
-                  Consulta Gratuita
+                  Fale com a equipe para uma avaliação do seu caso
                 </h3>
                 <p className="text-slate-600 text-sm">
-                  Agende uma conversa inicial sem compromisso
+                  Nossa equipe está pronta para avaliar sua situação
                 </p>
               </div>
 

--- a/src/pages/homepage/components/StickyCTABar.jsx
+++ b/src/pages/homepage/components/StickyCTABar.jsx
@@ -51,7 +51,7 @@ const StickyCTABar = () => {
                   Precisa de ajuda jurídica?
                 </h4>
                 <p className="text-xs text-slate-600">
-                  Consulta gratuita • Resposta em até 2h
+                  Fale com a equipe para uma avaliação do seu caso • Resposta em até 2h
                 </p>
               </div>
             </div>
@@ -63,7 +63,7 @@ const StickyCTABar = () => {
               </div>
               <div>
                 <h4 className="font-lora font-semibold text-slate-900 text-sm">
-                  Consulta gratuita
+                  Fale com a equipe para uma avaliação do seu caso
                 </h4>
               </div>
             </div>

--- a/src/pages/homepage/components/TestimonialsSection.jsx
+++ b/src/pages/homepage/components/TestimonialsSection.jsx
@@ -141,7 +141,7 @@ const TestimonialsSection = () => {
                 Pronto para resolver sua questão jurídica?
               </h3>
               <p className="text-indigo-100 mb-6">
-                Agende uma consulta gratuita e descubra como posso ajudar você a alcançar os melhores resultados.
+                Fale com a equipe para uma avaliação do seu caso e descubra como posso ajudar você a alcançar os melhores resultados.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <button


### PR DESCRIPTION
## Summary
- Update sticky CTA to invite case evaluation instead of free consultation
- Revise hero and testimonial sections to remove references to free consultations
- Adjust contact components to encourage speaking with the team for case evaluation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a703e3c4dc832cb8c402b8368b3e8a