### PR TITLE
Padroniza rodapé em todas as páginas

### DIFF
--- a/src/components/ui/Footer.jsx
+++ b/src/components/ui/Footer.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+const Footer = () => {
+  return (
+    <footer className="bg-slate-900 text-white py-12">
+      <div className="max-w-7xl mx-auto px-4 lg:px-6">
+        <div className="grid md:grid-cols-3 gap-8">
+          {/* Brand */}
+          <div className="space-y-4">
+            <div className="flex items-center space-x-3">
+              <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-indigo-600 to-slate-700 rounded-lg">
+                <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z" />
+                </svg>
+              </div>
+              <div>
+                <h3 className="font-lora font-semibold text-lg">Marcelo Baía</h3>
+                <p className="text-slate-400 text-sm">Advocacia</p>
+              </div>
+            </div>
+            <p className="text-slate-400 text-sm leading-relaxed">
+              Assessoria jurídica clara e segura para decisões importantes.
+              Atendimento humanizado online.
+            </p>
+          </div>
+
+          {/* Contact Info */}
+          <div className="space-y-4">
+            <h4 className="font-semibold text-white">Contato</h4>
+            <div className="space-y-2 text-sm">
+              <div className="flex items-center space-x-2">
+                <svg className="w-4 h-4 text-slate-400" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
+                </svg>
+                <a href="mailto:contato@marcelobaia.adv.br" className="text-slate-400">
+                  contato@marcelobaia.adv.br
+                </a>
+              </div>
+              <div className="flex items-center space-x-2">
+                <svg className="w-4 h-4 text-slate-400" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z" />
+                </svg>
+                <a href="tel:+5566999111314" className="text-slate-400">
+                  (66) 99911-1314
+                </a>
+              </div>
+              <div className="flex items-center space-x-2">
+                <svg className="w-4 h-4 text-slate-400" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
+                </svg>
+                <span className="text-slate-400">
+                  Rua Tiradentes, 1888 – Centro, Rondonópolis-MT – CEP 78.700-028
+                </span>
+              </div>
+              <div className="flex items-center space-x-2">
+                <svg className="w-4 h-4 text-slate-400" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 8a2 2 0 100 4 2 2 0 000-4z" />
+                </svg>
+                <span className="text-slate-400">
+                  Atendimento presencial mediante agendamento. Atendimento por telefone entre as 7:00h e 17:00h de segunda-feira à sexta-feira e via WhatsApp 24h por dia 7 dias por semana.
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Legal */}
+          <div className="space-y-4">
+            <h4 className="font-semibold text-white">Informações</h4>
+            <div className="space-y-2 text-sm text-slate-400">
+              <p>CNPJ: 34.362.076/0001-89</p>
+              <p>OAB/MT: 14.159-B</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t border-slate-800 mt-8 pt-8 text-center">
+          <p className="text-slate-400 text-sm">
+            © {new Date()?.getFullYear()} Marcelo Baía Advocacia. Todos os direitos reservados.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;
+

--- a/src/pages/PaginaNaoEncontrada.jsx
+++ b/src/pages/PaginaNaoEncontrada.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from 'components/ui/Button';
 import Icon from 'components/AppIcon';
+import Footer from 'components/ui/Footer';
 
 const PaginaNaoEncontrada = () => {
   const navigate = useNavigate();
@@ -11,39 +12,42 @@ const PaginaNaoEncontrada = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4">
-      <div className="text-center max-w-md">
-        <div className="flex justify-center mb-6">
-          <div className="relative">
-            <h1 className="text-9xl font-bold text-primary opacity-20">404</h1>
+    <div className="min-h-screen flex flex-col bg-background">
+      <div className="flex-grow flex flex-col items-center justify-center p-4">
+        <div className="text-center max-w-md">
+          <div className="flex justify-center mb-6">
+            <div className="relative">
+              <h1 className="text-9xl font-bold text-primary opacity-20">404</h1>
+            </div>
+          </div>
+
+          <h2 className="text-2xl font-medium text-onBackground mb-2">Página Não Encontrada</h2>
+          <p className="text-onBackground/70 mb-8">
+            A página que você procura não existe. Vamos voltar!
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button
+              variant="primary"
+              icon={<Icon name="ArrowLeft" />}
+              iconPosition="left"
+              onClick={() => window.history?.back()}
+            >
+                Voltar
+            </Button>
+
+            <Button
+              variant="outline"
+              icon={<Icon name="Home" />}
+              iconPosition="left"
+              onClick={handleGoHome}
+            >
+                Voltar ao Início
+            </Button>
           </div>
         </div>
-
-        <h2 className="text-2xl font-medium text-onBackground mb-2">Página Não Encontrada</h2>
-        <p className="text-onBackground/70 mb-8">
-          A página que você procura não existe. Vamos voltar!
-        </p>
-
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Button
-            variant="primary"
-            icon={<Icon name="ArrowLeft" />}
-            iconPosition="left"
-            onClick={() => window.history?.back()}
-          >
-              Voltar
-          </Button>
-
-          <Button
-            variant="outline"
-            icon={<Icon name="Home" />}
-            iconPosition="left"
-            onClick={handleGoHome}
-          >
-              Voltar ao Início
-          </Button>
-        </div>
       </div>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/areas-de-atuacao/index.jsx
+++ b/src/pages/areas-de-atuacao/index.jsx
@@ -6,6 +6,7 @@ import FAQSection from './components/FAQSection';
 import ConsultationWidget from './components/ConsultationWidget';
 import PreventiveLegalSection from './components/PreventiveLegalSection';
 import Icon from '../../components/AppIcon';
+import Footer from '../../components/ui/Footer';
 
 const AreasDeAtuacao = () => {
   const practiceAreas = [
@@ -279,108 +280,7 @@ const AreasDeAtuacao = () => {
 
         {/* Consultation Widget */}
         <ConsultationWidget />
-
-        {/* Footer */}
-        <footer className="bg-brand-primary text-white py-12 lg:py-16">
-          <div className="max-w-7xl mx-auto px-4 lg:px-6">
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8 mb-8">
-              {/* Logo and Description */}
-              <div className="lg:col-span-2">
-                <div className="flex items-center space-x-3 mb-4">
-                  <div className="w-12 h-12 bg-gradient-to-br from-brand-accent to-brand-accent/80 rounded-lg flex items-center justify-center">
-                    <Icon name="Scale" size={24} color="white" />
-                  </div>
-                  <div>
-                    <h3 className="font-lora font-semibold text-xl">Marcelo Baía</h3>
-                    <p className="text-white/80 text-sm">Advocacia</p>
-                  </div>
-                </div>
-                <p className="text-white/80 font-inter leading-relaxed mb-4">
-                  Assessoria jurídica clara e segura para decisões importantes. 
-                  Atendimento humanizado online com expertise técnica.
-                </p>
-                <div className="flex space-x-4">
-                  <a
-                    href="https://wa.me/5566999111314"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="w-10 h-10 bg-white/20 hover:bg-white/30 rounded-lg flex items-center justify-center transition-colors duration-200"
-                    aria-label="WhatsApp"
-                  >
-                    <Icon name="MessageCircle" size={20} />
-                  </a>
-                  <a
-                    href="tel:+5566999111314"
-                    className="w-10 h-10 bg-white/20 hover:bg-white/30 rounded-lg flex items-center justify-center transition-colors duration-200"
-                    aria-label="Ligar para (66) 99911-1314"
-                  >
-                    <Icon name="Phone" size={20} />
-                  </a>
-                </div>
-              </div>
-
-              {/* Quick Links */}
-              <div>
-                <h4 className="font-inter font-semibold text-lg mb-4">Links Rápidos</h4>
-                <ul className="space-y-2">
-                  <li><a href="/" className="text-white/80 hover:text-white font-inter text-sm transition-colors duration-200">Início</a></li>
-                    <li><a href="/sobre-marcelo-baia" className="text-white/80 hover:text-white font-inter text-sm transition-colors duration-200">Sobre Nós</a></li>
-                    <li><a href="/perguntas-frequentes" className="text-white/80 hover:text-white font-inter text-sm transition-colors duration-200">FAQ</a></li>
-                    <li><a href="/contato-consulta" className="text-white/80 hover:text-white font-inter text-sm transition-colors duration-200">Contato</a></li>
-                </ul>
-              </div>
-
-              {/* Contact Info */}
-              <div>
-                <h4 className="font-inter font-semibold text-lg mb-4">Contato</h4>
-                <div className="space-y-3">
-                  <div className="flex items-center space-x-3">
-                    <Icon name="MessageCircle" size={16} className="text-brand-accent" />
-                    <a
-                      href="https://wa.me/5566999111314"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-white/80 font-inter text-sm"
-                    >
-                      (66) 99911-1314
-                    </a>
-                  </div>
-                  <div className="flex items-center space-x-3">
-                    <Icon name="Phone" size={16} className="text-brand-accent" />
-                    <a href="tel:+5566999111314" className="text-white/80 font-inter text-sm">(66) 99911-1314</a>
-                  </div>
-                  <div className="flex items-center space-x-3">
-                    <Icon name="Mail" size={16} className="text-brand-accent" />
-                    <a href="mailto:contato@marcelobaia.adv.br" className="text-white/80 font-inter text-sm">contato@marcelobaia.adv.br</a>
-                  </div>
-                  <div className="flex items-start space-x-3">
-                    <Icon name="MapPin" size={16} className="text-brand-accent mt-0.5" />
-                    <span className="text-white/80 font-inter text-sm">Rua Tiradentes, 1888 – Centro, Rondonópolis-MT – CEP 78.700-028</span>
-                  </div>
-                  <div className="flex items-start space-x-3">
-                    <Icon name="Clock" size={16} className="text-brand-accent mt-0.5" />
-                    <span className="text-white/80 font-inter text-sm">Atendimento presencial mediante agendamento. Atendimento por telefone entre as 7:00h e 17:00h de segunda-feira à sexta-feira e via WhatsApp 24h por dia 7 dias por semana.</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Bottom Bar */}
-            <div className="border-t border-white/20 pt-8 flex flex-col md:flex-row justify-between items-center">
-              <p className="text-white/60 font-inter text-sm mb-4 md:mb-0">
-                © {new Date()?.getFullYear()} Marcelo Baía Advocacia. Todos os direitos reservados.
-              </p>
-              <div className="flex space-x-6">
-                <a href="#" className="text-white/60 hover:text-white font-inter text-sm transition-colors duration-200">
-                  Política de Privacidade
-                </a>
-                <a href="#" className="text-white/60 hover:text-white font-inter text-sm transition-colors duration-200">
-                  Termos de Uso
-                </a>
-              </div>
-            </div>
-          </div>
-        </footer>
+        <Footer />
       </div>
     </>
   );

--- a/src/pages/contato-consulta/index.jsx
+++ b/src/pages/contato-consulta/index.jsx
@@ -6,6 +6,7 @@ import ContactForm from './components/ContactForm';
 import OfficeLocation from './components/OfficeLocation';
 import ConsultationPrep from './components/ConsultationPrep';
 import TrustSignals from './components/TrustSignals';
+import Footer from '../../components/ui/Footer';
 
 const ContatoConsulta = () => {
   const handleWhatsAppClick = () => {
@@ -41,9 +42,11 @@ const ContatoConsulta = () => {
         <OfficeLocation />
         
         <ConsultationPrep />
-        
+
         <TrustSignals />
       </main>
+
+      <Footer />
 
       {/* Sticky Contact Bar */}
       <div className="fixed bottom-0 left-0 right-0 z-40 bg-white/95 backdrop-blur-md border-t border-slate-200 p-4 lg:hidden">

--- a/src/pages/pagina-area-de-atuacao/index.jsx
+++ b/src/pages/pagina-area-de-atuacao/index.jsx
@@ -8,6 +8,7 @@ import ContextualFAQ from './components/ContextualFAQ';
 import CaseStudyApproach from './components/CaseStudyApproach';
 import PracticeAreaSelector from './components/PracticeAreaSelector';
 import ContactCTA from './components/ContactCTA';
+import Footer from '../../components/ui/Footer';
 
 const PaginaAreaDeAtuacao = () => {
   const [searchParams] = useSearchParams();
@@ -98,70 +99,12 @@ const PaginaAreaDeAtuacao = () => {
           <CaseStudyApproach practiceArea={currentArea} />
           
           <ContextualFAQ practiceArea={currentArea} />
-          
+
           <ContactCTA practiceArea={currentArea} />
-          
+
           <PracticeAreaSelector currentArea={currentArea} />
         </main>
-
-        {/* Footer */}
-        <footer className="bg-slate-900 text-white py-12">
-          <div className="max-w-7xl mx-auto px-4 lg:px-6">
-            <div className="grid md:grid-cols-3 gap-8">
-              {/* Contact Info */}
-              <div>
-                <h3 className="font-lora font-semibold text-xl mb-4">Contato</h3>
-                <div className="space-y-3">
-                  <p className="font-inter text-slate-300">
-                    📍 Rua Tiradentes, 1888 – Centro, Rondonópolis-MT – CEP 78.700-028
-                  </p>
-                  <p className="font-inter text-slate-300">
-                    📞 <a href="tel:+5566999111314" className="text-slate-300">(66) 99911-1314</a>
-                  </p>
-                  <p className="font-inter text-slate-300">
-                    💬 <a href="https://wa.me/5566999111314" target="_blank" rel="noopener noreferrer" className="text-slate-300">(66) 99911-1314</a>
-                  </p>
-                  <p className="font-inter text-slate-300">
-                    ✉️ <a href="mailto:contato@marcelobaia.adv.br" className="text-slate-300">contato@marcelobaia.adv.br</a>
-                  </p>
-                </div>
-              </div>
-
-              {/* Practice Areas */}
-              <div>
-                <h3 className="font-lora font-semibold text-xl mb-4">Áreas de Atuação</h3>
-                <div className="space-y-2">
-                  <p className="font-inter text-slate-300">Direito Civil</p>
-                  <p className="font-inter text-slate-300">Direito do Consumidor</p>
-                  <p className="font-inter text-slate-300">Direito de Família</p>
-                  <p className="font-inter text-slate-300">Direito Empresarial</p>
-                </div>
-              </div>
-
-              {/* Legal */}
-              <div>
-                <h3 className="font-lora font-semibold text-xl mb-4">Informações Legais</h3>
-                <div className="space-y-2">
-                  <p className="font-inter text-slate-300 text-sm">
-                    OAB/MT 14.159-B
-                  </p>
-                  <p className="font-inter text-slate-300 text-sm">
-                    Atendimento presencial mediante agendamento
-                  </p>
-                  <p className="font-inter text-slate-300 text-sm">
-                    Atendimento por telefone entre as 7:00h e 17:00h de segunda-feira à sexta-feira e via WhatsApp 24h por dia 7 dias por semana
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className="border-t border-slate-700 mt-8 pt-8 text-center">
-              <p className="font-inter text-slate-400 text-sm">
-                © {new Date()?.getFullYear()} Marcelo Baía Advocacia. Todos os direitos reservados.
-              </p>
-            </div>
-          </div>
-        </footer>
+        <Footer />
       </div>
     </>
   );

--- a/src/pages/pagina-inicial/index.jsx
+++ b/src/pages/pagina-inicial/index.jsx
@@ -6,6 +6,7 @@ import FAQPreviewSection from './components/FAQPreviewSection';
 import TestimonialsSection from './components/TestimonialsSection';
 import ContactSection from './components/ContactSection';
 import StickyCTABar from './components/StickyCTABar';
+import Footer from '../../components/ui/Footer';
 
 const PaginaInicial = () => {
   return (
@@ -19,77 +20,7 @@ const PaginaInicial = () => {
         <ContactSection />
       </main>
       <StickyCTABar />
-      {/* Footer */}
-      <footer className="bg-slate-900 text-white py-12">
-        <div className="max-w-7xl mx-auto px-4 lg:px-6">
-          <div className="grid md:grid-cols-3 gap-8">
-            {/* Brand */}
-            <div className="space-y-4">
-              <div className="flex items-center space-x-3">
-                <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-indigo-600 to-slate-700 rounded-lg">
-                  <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
-                  </svg>
-                </div>
-                <div>
-                  <h3 className="font-lora font-semibold text-lg">Marcelo Baía</h3>
-                  <p className="text-slate-400 text-sm">Advocacia</p>
-                </div>
-              </div>
-              <p className="text-slate-400 text-sm leading-relaxed">
-                Assessoria jurídica clara e segura para decisões importantes.
-                Atendimento humanizado online.
-              </p>
-            </div>
-
-            {/* Contact Info */}
-            <div className="space-y-4">
-              <h4 className="font-semibold text-white">Contato</h4>
-              <div className="space-y-2 text-sm">
-                <div className="flex items-center space-x-2">
-                  <svg className="w-4 h-4 text-slate-400" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
-                  </svg>
-                  <a href="mailto:contato@marcelobaia.adv.br" className="text-slate-400">contato@marcelobaia.adv.br</a>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <svg className="w-4 h-4 text-slate-400" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/>
-                  </svg>
-                  <a href="tel:+5566999111314" className="text-slate-400">(66) 99911-1314</a>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <svg className="w-4 h-4 text-slate-400" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
-                  </svg>
-                  <span className="text-slate-400">Rua Tiradentes, 1888 – Centro, Rondonópolis-MT – CEP 78.700-028</span>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <svg className="w-4 h-4 text-slate-400" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M12 8a2 2 0 100 4 2 2 0 000-4z"/>
-                  </svg>
-                  <span className="text-slate-400">Atendimento presencial mediante agendamento. Atendimento por telefone entre as 7:00h e 17:00h de segunda-feira à sexta-feira e via WhatsApp 24h por dia 7 dias por semana.</span>
-                </div>
-              </div>
-            </div>
-
-            {/* Legal */}
-            <div className="space-y-4">
-              <h4 className="font-semibold text-white">Informações</h4>
-              <div className="space-y-2 text-sm text-slate-400">
-                <p>CNPJ: 34.362.076/0001-89</p>
-                <p>OAB/MT: 14.159-B</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="border-t border-slate-800 mt-8 pt-8 text-center">
-            <p className="text-slate-400 text-sm">
-              © {new Date()?.getFullYear()} Marcelo Baía Advocacia. Todos os direitos reservados.
-            </p>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/perguntas-frequentes/index.jsx
+++ b/src/pages/perguntas-frequentes/index.jsx
@@ -7,6 +7,7 @@ import FAQAccordion from './components/FAQAccordion';
 import PopularQuestions from './components/PopularQuestions';
 import ContactCTA from './components/ContactCTA';
 import Icon from '../../components/AppIcon';
+import Footer from '../../components/ui/Footer';
 
 const PerguntasFrequentes = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -410,9 +411,10 @@ const PerguntasFrequentes = () => {
             </div>
           </div>
         </section>
+        <Footer />
       </div>
     </>
   );
 };
 
-  export default PerguntasFrequentes;
+export default PerguntasFrequentes;

--- a/src/pages/sobre-marcelo-baia/index.jsx
+++ b/src/pages/sobre-marcelo-baia/index.jsx
@@ -7,6 +7,7 @@ import MethodologySection from './components/MethodologySection';
 import CredentialsSection from './components/CredentialsSection';
 import TestimonialsSection from './components/TestimonialsSection';
 import ContactSection from './components/ContactSection';
+import Footer from '../../components/ui/Footer';
 
 const SobreMarceloBaia = () => {
   const handleContactClick = () => {
@@ -84,59 +85,7 @@ const SobreMarceloBaia = () => {
             <ContactSection />
           </div>
         </main>
-
-        {/* Footer */}
-        <footer className="bg-brand-primary text-white py-12">
-          <div className="max-w-7xl mx-auto px-4 lg:px-6">
-            <div className="grid md:grid-cols-3 gap-8">
-              {/* Brand */}
-              <div>
-                <h3 className="font-lora text-xl font-semibold mb-4">
-                  Marcelo Baía Advocacia
-                </h3>
-                <p className="text-slate-300 text-sm leading-relaxed mb-4">
-                  Assessoria jurídica clara e segura para decisões importantes da sua vida. 
-                  Atendimento humanizado e comunicação transparente.
-                </p>
-                <p className="text-slate-400 text-xs">
-                  OAB/MT 14.159-B
-                </p>
-              </div>
-
-              {/* Contact Info */}
-              <div>
-                <h4 className="font-semibold mb-4">Contato</h4>
-                <div className="space-y-2 text-sm text-slate-300">
-                  <p>📍 Rua Tiradentes, 1888 – Centro, Rondonópolis-MT – CEP 78.700-028</p>
-                  <p>📞 <a href="tel:+5566999111314" className="text-slate-300">(66) 99911-1314</a></p>
-                  <p>💬 <a href="https://wa.me/5566999111314" target="_blank" rel="noopener noreferrer" className="text-slate-300">(66) 99911-1314</a></p>
-                  <p>✉️ <a href="mailto:contato@marcelobaia.adv.br" className="text-slate-300">contato@marcelobaia.adv.br</a></p>
-                  <p>🕒 Atendimento presencial mediante agendamento. Atendimento por telefone entre as 7:00h e 17:00h de segunda-feira à sexta-feira e via WhatsApp 24h por dia 7 dias por semana.</p>
-                </div>
-              </div>
-
-              {/* Areas */}
-              <div>
-                <h4 className="font-semibold mb-4">Áreas de Atuação</h4>
-                <ul className="space-y-1 text-sm text-slate-300">
-                  <li>• Direito Civil</li>
-                  <li>• Direito do Consumidor</li>
-                  <li>• Direito de Família</li>
-                  <li>• Direito Empresarial</li>
-                </ul>
-              </div>
-            </div>
-
-            <div className="border-t border-slate-700 mt-8 pt-8 text-center">
-              <p className="text-slate-400 text-sm">
-                © {new Date()?.getFullYear()} Marcelo Baía Advocacia. Todos os direitos reservados.
-              </p>
-              <p className="text-slate-500 text-xs mt-2">
-                Este site está em conformidade com o Provimento 205/2021 da OAB e a LGPD.
-              </p>
-            </div>
-          </div>
-        </footer>
+        <Footer />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- Cria componente reutilizável de rodapé com informações de contato e dados legais
- Substitui marcações individuais pelo novo componente em todas as páginas, incluindo início, áreas de atuação, FAQ, contato e erro 404

## Testing
- `npm test` *(missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a7a1c9b6e8832cb78478bba6ca6e42