### PR TITLE
Add social media buttons to site layout

### DIFF
--- a/src/components/ui/Footer.jsx
+++ b/src/components/ui/Footer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import Icon from '../AppIcon';
+import SocialLinks from './SocialLinks';
 
 const Footer = () => {
   return (
@@ -21,42 +22,7 @@ const Footer = () => {
             <p className="text-slate-400 text-sm leading-relaxed">
               Assessoria jurídica clara e segura para decisões importantes. Atendimento humanizado online.
             </p>
-            <div className="flex space-x-4">
-              <a
-                href="https://www.linkedin.com/in/marcelo-baia"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-slate-400 hover:text-white"
-              >
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
-                  <rect width="4" height="12" x="2" y="9" />
-                  <circle cx="4" cy="4" r="2" />
-                </svg>
-              </a>
-              <a
-                href="https://www.instagram.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-slate-400 hover:text-white"
-              >
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <rect width="20" height="20" x="2" y="2" rx="5" ry="5" />
-                  <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
-                  <line x1="17.5" x2="17.51" y1="6.5" y2="6.5" />
-                </svg>
-              </a>
-              <a
-                href="https://wa.me/5566999111314"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-slate-400 hover:text-white"
-              >
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719" />
-                </svg>
-              </a>
-            </div>
+            <SocialLinks />
           </div>
 
           {/* Navigation */}

--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Icon from '../AppIcon';
 import Button from './Button';
+import SocialLinks from './SocialLinks';
 import { CONTACT } from '../../config/contact';
 
 const Header = () => {
@@ -89,6 +90,7 @@ const Header = () => {
 
           {/* Desktop CTA Buttons */}
           <div className="hidden lg:flex items-center space-x-3">
+            <SocialLinks iconClassName="text-slate-700 hover:text-brand-accent" />
             <Button
               asChild
               variant="outline"
@@ -157,7 +159,9 @@ const Header = () => {
                 </Link>
               ))}
             </nav>
-            
+
+            <SocialLinks className="justify-center mt-6" iconClassName="text-slate-700 hover:text-brand-accent" />
+
             {/* Mobile CTA Buttons */}
             <div className="flex flex-col space-y-3 mt-6 pt-4 border-t border-border">
               <Button

--- a/src/components/ui/SocialLinks.jsx
+++ b/src/components/ui/SocialLinks.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Icon from '../AppIcon';
+
+const SocialLinks = ({ className = '', iconClassName = 'text-slate-400 hover:text-white' }) => {
+  const links = [
+    { href: 'https://www.youtube.com/@MarceloBa%C3%ADa-c8h', icon: 'Youtube', label: 'YouTube' },
+    { href: 'https://www.linkedin.com/in/marcelo-ba%C3%ADa-29433662/', icon: 'Linkedin', label: 'LinkedIn' },
+    { href: 'https://www.facebook.com/share/1K2HTpSdcG/', icon: 'Facebook', label: 'Facebook' },
+    { href: 'https://www.instagram.com/advocaciamarcelobaia', icon: 'Instagram', label: 'Instagram' },
+  ];
+
+  return (
+    <div className={`flex space-x-4 ${className}`}>
+      {links.map((link) => (
+        <a
+          key={link.href}
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={link.label}
+          className={iconClassName}
+        >
+          <Icon name={link.icon} size={20} />
+        </a>
+      ))}
+    </div>
+  );
+};
+
+export default SocialLinks;
+


### PR DESCRIPTION
## Summary
- create reusable SocialLinks component linking to YouTube, LinkedIn, Facebook, and Instagram
- show social icons in header and footer so every view exposes the profile links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a8b37b3640832c835f17b435d9fb60