### PR TITLE
Refine social media icons

### DIFF
--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -7,7 +7,7 @@ function Icon({
     size = 24,
     color = "currentColor",
     className = "",
-    strokeWidth = 2,
+    strokeWidth = 1.5,
     ...props
 }) {
     const IconComponent = LucideIcons?.[name];

--- a/src/components/ui/SocialLinks.jsx
+++ b/src/components/ui/SocialLinks.jsx
@@ -10,7 +10,7 @@ const SocialLinks = ({ className = '', iconClassName = 'text-slate-400 hover:tex
   ];
 
   return (
-    <div className={`flex space-x-4 ${className}`}>
+    <div className={`flex items-center gap-2 ${className}`}>
       {links.map((link) => (
         <a
           key={link.href}
@@ -20,7 +20,7 @@ const SocialLinks = ({ className = '', iconClassName = 'text-slate-400 hover:tex
           aria-label={link.label}
           className={iconClassName}
         >
-          <Icon name={link.icon} size={20} />
+          <Icon name={link.icon} size={18} strokeWidth={1.25} />
         </a>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Reduce default icon stroke width for slimmer appearance
- Tighten spacing and lighten stroke on social media links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a8b5f3f618832cb2c43138197a8b6e