### PR TITLE
Add Google Ads tag to site

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -12,6 +12,15 @@
   <link rel="manifest" href="/site.webmanifest" />
   <meta property="og:image" content="/assets/images/logo-512x512.png" />
   <meta name="twitter:image" content="/assets/images/logo-512x512.png" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-687507231"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'AW-687507231');
+  </script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/index.html
+++ b/index.html
@@ -12,6 +12,15 @@
   <link rel="manifest" href="/site.webmanifest" />
   <meta property="og:image" content="/assets/images/logo-512x512.png" />
   <meta name="twitter:image" content="/assets/images/logo-512x512.png" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-687507231"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'AW-687507231');
+  </script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,15 @@
   <link rel="manifest" href="/site.webmanifest" />
   <meta property="og:image" content="/assets/images/logo-512x512.png" />
   <meta name="twitter:image" content="/assets/images/logo-512x512.png" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-687507231"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'AW-687507231');
+  </script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- embed Google Ads global site tag in main HTML pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ac519e3370832cb9561aad84ece2d6